### PR TITLE
Add support for safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var Range = React.createClass({
   },
   onRangeChange: function(e) {
     this.props.onMouseMove(e);
-    if (e.buttons !== 1) return;
+    if (e.buttons !== 1 && e.button !== 0) return;
     this.props.onChange(e);
   },
   onRangeKeyDown: function(e) {


### PR DESCRIPTION
`event.buttons` is undefined in safari. This adds a `event.button` check, [which is supported in safari](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button).

/cc @scothis 
