### PR TITLE
Use a callback ref instead of findDOMNode (fixes #14)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var React = require('react');
-var ReactDOM = require('react-dom');
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 var Range = React.createClass({
@@ -34,8 +33,11 @@ var Range = React.createClass({
     this.props.onKeyDown(e);
     this.props.onChange(e);
   },
+  setRangeRef: function(ref) {
+    this.range = ref;
+  },
   componentWillReceiveProps: function(props) {
-    ReactDOM.findDOMNode(this).value = props.value;
+    this.range.value = props.value;
   },
   render: function() {
     var props = _extends({}, this.props, {
@@ -43,7 +45,8 @@ var Range = React.createClass({
       onClick: this.onRangeClick,
       onKeyDown: this.onRangeKeyDown,
       onMouseMove: this.onRangeChange,
-      onChange: function() {}
+      onChange: function() {},
+      ref: this.setRangeRef
     });
     delete props.value;
     return React.createElement(

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "onChange"
   ],
   "dependencies": {
-    "react": "^0.14.2",
-    "react-dom": "^0.14.2"
+    "react": "^0.14.2"
   },
   "devDependencies": {
     "babel-core": "^5.8.22",


### PR DESCRIPTION
As mentioned in #14, I was getting

```
Uncaught Invariant Violation: traverseParentPath(…): Cannot traverse from and to the same ID, ``
```

after upgrading to React v15 today, and traced it to the `ReactDOM.findDOMNode` call in `react-range`. Changing the component to use a callback ref instead fixed it. See the issue (#14) for slightly more elaboration.
